### PR TITLE
fixedPagination 

### DIFF
--- a/src/pages/TopWalls.jsx
+++ b/src/pages/TopWalls.jsx
@@ -22,6 +22,8 @@ const TopWalls = () => {
     isError: error,
   } = useGetTopWallsQuery({ page, toprange });
 
+  console.log(walls);
+
   useEffect(() => {
     if (toprange == "1d") {
       setDays("24 Hours");
@@ -55,6 +57,12 @@ const TopWalls = () => {
         ) : error ? (
           <ErrorComponent
             message={"Some Error Occured while loading wallpapers"}
+          />
+        ) : page > walls.meta.last_page ? (
+          <ErrorComponent
+            message={
+              "No more wallpapers available in this range. Please choose a different time range or explore other categories."
+            }
           />
         ) : (
           <>


### PR DESCRIPTION
**Description of Changes**

This pull request addresses an issue where users were able to navigate beyond the last page of available wallpapers without receiving any error messages. A new implementation was added to disable the "NEXT" button when users are on the last page, preventing them from going beyond the available content.

**Previous Behavior**
Users were able to navigate to pages beyond the last available page of wallpapers.

**Updated Behavior**
Now users get a error message explaining they have reached the last page

**Screenshots**
<img width="960" alt="chrome_TUWLytB5zZ" src="https://github.com/xtremeandroid/heavenWalls/assets/77891752/326b20ab-ec90-4954-81d6-d819eab73c0f">
