### PR TITLE
Fixed pagination buttons allowing to move beyond last page

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -14,6 +14,7 @@ const Pagination = ({ noofpages, changePage, page }) => {
         bgColor={"blackAlpha.900"}
         color={"white"}
         onClick={() => changePage(page + 1)}
+        isDisabled={page === noofpages}
       >
         NEXT
       </Button>
@@ -21,16 +22,9 @@ const Pagination = ({ noofpages, changePage, page }) => {
         bgColor={"blackAlpha.900"}
         color={"white"}
         onClick={() => changePage(page - 1)}
+        isDisabled={page === 1}
       >
         PREV
-      </Button>
-
-      <Button
-        bgColor={"blackAlpha.900"}
-        color={"white"}
-        onClick={() => changePage(noofpages)}
-      >
-        LAST
       </Button>
     </HStack>
   );


### PR DESCRIPTION
**Description of Changes**

This pull request resolves an issue where users were able to click the "NEXT" and "LAST" buttons when they were on the last page, and the "PREV" button when they were on the first page. The buttons are now properly disabled under these conditions, improving the usability of the pagination system.

**Changes Made**

- The "NEXT" and "LAST" buttons are disabled when the user is on the last page (`page === noofpages`).
- The "PREV" button is disabled when the user is on the first page (`page === 1`).

<img width="960" alt="chrome_V7tMvYbaoc" src="https://github.com/xtremeandroid/heavenWalls/assets/77891752/2e3871a9-07a3-43b4-8961-57f55ff7b6bc">
